### PR TITLE
Update update_notifications.yaml

### DIFF
--- a/.homeassistant/packages/update_notifications.yaml
+++ b/.homeassistant/packages/update_notifications.yaml
@@ -66,7 +66,7 @@ automation:
               - condition: template
                 value_template: "{{ (states('sensor.updater_supervisor') | float) != 0 }}"
               - condition: template
-                value_template: "{{ (states('sensor.hacs') | float) != 0 }}"
+                value_template: "{{ (states('sensor.hacs') | float(0)) != 0 }}"
           sequence:
           - service: persistent_notification.create
             data_template:


### PR DESCRIPTION
Fixing error:
Template warning: 'float' got invalid input 'unknown' when rendering template '{{ (states('sensor.hacs') | float) != 0 }}' but no default was specified. Currently 'float' will return '0', however this template will fail to render in Home Assistant core 2022.1