### PR TITLE
Update update_notifications.yaml

### DIFF
--- a/.homeassistant/packages/update_notifications.yaml
+++ b/.homeassistant/packages/update_notifications.yaml
@@ -64,7 +64,7 @@ automation:
               - condition: template
                 value_template: "{{ states('sensor.updater_hassos') == 'on' }}"
               - condition: template
-                value_template: "{{ (states('sensor.updater_supervisor') | float) != 0 }}"
+                value_template: "{{ (states('sensor.updater_supervisor') | float(0)) != 0 }}"
               - condition: template
                 value_template: "{{ (states('sensor.hacs') | float(0)) != 0 }}"
           sequence:
@@ -85,7 +85,7 @@ automation:
                 {% endif %}
 
                 {% set supervisor_entity_id = 'sensor.updater_supervisor' %}
-                {% if (states(supervisor_entity_id) | float) != 0 %}
+                {% if (states(supervisor_entity_id) | float(0)) != 0 %}
                 [Add-ons](/hassio/dashboard)
                   {% for addon in state_attr(supervisor_entity_id, 'addons') %}
                 * [**{{ addon.name }}**](/hassio/addon/{{ addon["slug"] }}/info) {{ addon["version"] }} -> {{ addon["version_latest"] }}
@@ -93,7 +93,7 @@ automation:
                 {% endif %}
 
                 {% set hacs_entity_id = 'sensor.hacs' %}
-                {% if (states(hacs_entity_id) | float) != 0 %}
+                {% if (states(hacs_entity_id) | float(0)) != 0 %}
                 [HACS](/hacs/entry)
                   {% for repo in state_attr(hacs_entity_id, 'repositories') %}
                 * **{{ repo.display_name }}** {{ repo["installed_version"] }} -> {{ repo["available_version"] }}

--- a/.homeassistant/packages/update_notifications.yaml
+++ b/.homeassistant/packages/update_notifications.yaml
@@ -75,7 +75,7 @@ automation:
                 {% set core_entity_id = 'sensor.updater_core' %}
                 {% set os_entity_id = 'sensor.updater_hassos' %}
                 {% if states(core_entity_id) == 'on' or states(os_entity_id) == 'on' %}
-                [Home Assistant](/hassio/dashboard)
+                [Home Assistant](/config/dashboard)
                   {% if states(core_entity_id) == 'on' %}
                 * **Core** {{ state_attr(core_entity_id,"current_version") }} -> {{ state_attr(core_entity_id,"newest_version") }}  [`PRE-CHECK LOG`](/hassio/addon/core_check_config/logs)
                   {% endif %}


### PR DESCRIPTION
Change link to OS and Core updates to the new configuration panel, which was introduced with 2021.11 release: https://www.home-assistant.io/blog/2021/12/11/release-202112/#brand-new-configuration-panel